### PR TITLE
fix: add vercel.json to handle 404 on page reload

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
#This PR fixes the 404 error that occurs when refreshing routes (like /about, /contact, etc.) in a React app deployed on Vercel.

# #Problem:
When a user refreshes a route, Vercel tries to look for a file like /about and throws a 404 because that file doesn't exist.

##Solution:
Added a `vercel.json` file with a rewrite rule:

`{
  "rewrites": [
    { "source": "/(.*)", "destination": "/" }
  ]
}
`

* This tells Vercel to serve the root index.html for any unknown path so that React Router can handle the routing on the client side*